### PR TITLE
Docker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+TOKEN=abcdefghijklmnopqrstuvwxyz0123456789

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,6 @@ WORKDIR /app
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 
-COPY . .
+COPY src src
 
 CMD [ "python3", "-m" , "src.bot"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.9-alpine
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
+COPY . .
+
+CMD [ "python3", "-m" , "src.bot"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+
+services:
+  bot:
+    build: .
+    restart: unless-stopped
+    volumes:
+    - data:/app/data
+    - ./config:/app/config
+
+volumes:
+  data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ services:
     volumes:
     - data:/app/data
     - ./config:/app/config
+    environment:
+    - TOKEN
 
 volumes:
   data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ idna==3.3
 multidict==6.0.2
 py-cord==2.0.0rc1
 pycodestyle==2.8.0
+python-dotenv==0.20.0
 toml==0.10.2
 typing_extensions==4.1.1
 yarl==1.7.2

--- a/src/bot.py
+++ b/src/bot.py
@@ -11,9 +11,19 @@
         Used for: please see helper_functions.py docstrings for an explanation.
     """
 import discord
+from os import environ
+from dotenv import load_dotenv
 from src.logger.ownlogger import log
 from src.helper_functions import from_project_root, config_var
 from src.sqlite.database_initialiser import db_init
+
+
+load_dotenv()
+
+if "TOKEN" not in environ:
+    raise RuntimeError("TOKEN environment variable not set, exiting.")
+
+__token__ = environ.get("TOKEN")
 
 db_init()  # Ensure the database tables exist
 bot = discord.Bot()
@@ -24,28 +34,10 @@ async def on_ready():
     """Gets executed once the bot is logged in.
     """
     await bot.change_presence(activity=discord.Game('Die Taverne hat geöffnet!'))
-    # If a file token.txt exists: Run the bot. If not:
-    # Ask for the token to be stored in the file, and create the file.
 
 
-try:
-    with open(from_project_root('/config/token.txt'), encoding='utf-8') as token_file:
-        __token__ = token_file.read()
-
-        # Load all the cogs
-        bot.load_extension("src.commands.utility")
-        bot.load_extension("src.commands.dm_tools")
-        # Connect the bot to the discord api
-        bot.run(__token__)
-except FileNotFoundError:
-
-    log("Please enter your Bot Token. It will be stored in" +
-        "'./config/token.txt', which is ignored by .gitignore.", 'red')
-    # Getting the input as a variable BEFORE creating the file means,
-    # that the created file cannot be empty if the program aborts at this point.
-    token = input()
-    with open(from_project_root(
-            '/config/token.txt'), 'w', encoding='utf-8') as tokenfile:
-        tokenfile.write(token)
-        tokenfile.close()
-    log("Token stored. Please restart the bot.")
+# Load all the cogs
+bot.load_extension("src.commands.utility")
+bot.load_extension("src.commands.dm_tools")
+# Connect the bot to the discord api
+bot.run(__token__)

--- a/src/sqlite/database_handler.py
+++ b/src/sqlite/database_handler.py
@@ -1,3 +1,4 @@
+import os
 import sqlite3
 from src.helper_functions import from_project_root
 from src.logger.ownlogger import log
@@ -23,6 +24,7 @@ class Connection(metaclass=ConnectionMeta):
         """
         conn = None
         try:
+            os.makedirs(from_project_root('/data'), exist_ok=True)
             conn = sqlite3.connect(from_project_root('/data/campaign.db'))
             return conn
         except sqlite3.OperationalError as e:


### PR DESCRIPTION
Adds a basic Docker configuration, including a docker-compose.yml for easy deployment.

To run the bot directly, either `cp .env.example .env` and fill in the TOKEN, or run `TOKEN=... python -m src.bot`

To build the image and run the container:
```sh
docker build -t magicaltavern .
docker run -it -e TOKEN=... -v "$(pwd)/config:/app/config" -v "data:/app/data" magicaltavern
```

Or using docker compose (for production deployment), fill in `.env` and run:
```sh
docker compose up -d --build
```

Documentation still needs to be updated, if everything is okay like this.